### PR TITLE
CMS 5 compatibility upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
-
 {
   "name": "level51/silverstripe-excel-export",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "time": "2021-08-09",
   "description": "GridField button for excel exports",
   "type": "silverstripe-vendormodule",
@@ -18,9 +17,9 @@
   ],
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.1",
-    "silverstripe/framework": "^4.0",
-    "phpoffice/phpspreadsheet": "^1.11"
+    "php": "^8.1",
+    "silverstripe/framework": "^5.0",
+    "phpoffice/phpspreadsheet": "^2.0"
   },
   "extra": {
     "installer-name": "silverstripe-excel-export"

--- a/src/GridFieldExcelExportButton.php
+++ b/src/GridFieldExcelExportButton.php
@@ -143,7 +143,9 @@ class GridFieldExcelExportButton implements GridField_HTMLProvider, GridField_Ac
                         }
                     }
 
-                    $value = str_replace(array("\r", "\n"), "\n", $value);
+                    // Replace "\r" and "\n" characters in the value with "\n",
+                    // or default to an empty string if $value is null
+                    $value = str_replace(["\r", "\n"], "\n", $value ?? '');
 
                     // [SS-2017-007] Sanitise XLS executable column values with a leading tab
                     if (!Config::inst()->get(get_class($this), 'xls_export_disabled')


### PR DESCRIPTION
Also handled deprecated null haystack `str_replace()` calls by providing comments and null coalescing into empty strings.

Tested against framework version `5.1.0`

Resolves: #7 